### PR TITLE
Measure execution time of tasks more correctly and `debug` is `false` as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ You can know whether the task is executed or not by using `isRunIdleTask` .
 ```javascript
 configureIdleTask({
   interval: 1000, // ms
-  debug: false,
+  debug: process.env.NODE_ENV === 'development',
   timeout: 3000,
 });
 ```
@@ -320,7 +320,7 @@ If `debug` is `true`, you can know how long did it take to finish the task via t
 
 I recommend less than **50 ms** to execute a task because of [RAIL model](https://web.dev/i18n/en/rail/) .
 
-The default is `process.env.NODE_ENV === 'development'` .
+The default is `false` .
 
 #### `timeout?: number`
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -328,7 +328,7 @@ describe('idle-task', () => {
 
       describe('task took over 50 ms', () => {
         beforeEach(() => {
-          idleTaskModule!.setIdleTask(createTask(mockFirstTask, 51));
+          idleTaskModule!.setIdleTask(createTask(mockFirstTask, 50.001));
           runRequestIdleCallback();
         });
 
@@ -340,14 +340,14 @@ describe('idle-task', () => {
           expect(console.info).not.toHaveBeenCalled();
         });
 
-        it('include 51 ms', () => {
-          expect((console.warn as any).mock.calls[0][2]).toMatch('51 ms');
+        it('include 50.01 ms', () => {
+          expect((console.warn as any).mock.calls[0][2]).toMatch('50.01 ms');
         });
       });
 
       describe('task took less than 50 ms', () => {
         beforeEach(() => {
-          idleTaskModule!.setIdleTask(createTask(mockFirstTask, 50));
+          idleTaskModule!.setIdleTask(createTask(mockFirstTask, 49.999));
           runRequestIdleCallback();
         });
 
@@ -359,7 +359,7 @@ describe('idle-task', () => {
           expect(console.info).toHaveBeenCalled();
         });
 
-        it('include 51 ms', () => {
+        it('include 50 ms', () => {
           expect((console.info as any).mock.calls[0][2]).toMatch('50 ms');
         });
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,9 +82,9 @@ const runIdleTasks = (deadline: IdleDeadline): void => {
       }
     };
     if (taskGlobalOptions.debug) {
-      const start = Date.now();
+      const start = performance.now();
       executeTask();
-      const executionTime = Date.now() - start;
+      const executionTime = Math.ceil((performance.now() - start) * 100) / 100;
       console[executionTime > 50 ? 'warn' : 'info'](
         `%cidle-task`,
         `background: #717171; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export type ConfigureOptions = {
 };
 
 let taskGlobalOptions: ConfigureOptions = {
-  debug: process.env.NODE_ENV === 'development',
+  debug: false,
   cache: true,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,14 +85,13 @@ const runIdleTasks = (deadline: IdleDeadline): void => {
       const start = Date.now();
       executeTask();
       const executionTime = Date.now() - start;
-      const logArgs = [
+      console[executionTime > 50 ? 'warn' : 'info'](
         `%cidle-task`,
         `background: #717171; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;`,
         `${task[idleTaskNameProp] || 'anonymous'}(${
           task[idleTaskIdProp]
-        }) took ${executionTime} ms`,
-      ];
-      console[executionTime > 50 ? 'warn' : 'info'](...logArgs);
+        }) took ${executionTime} ms`
+      );
     } else {
       executeTask();
     }


### PR DESCRIPTION
- [feat: measure execution time of tasks more correctly](https://github.com/hiroki0525/idle-task/commit/dcc93c4c56a561294a246092c821e657230d1002)
- [fix: debug is false as default](https://github.com/hiroki0525/idle-task/commit/a852bb6bdd92696203e928b5956af4cf80c9960c)