### PR TITLE
feat: add `GetResultFromIdleTaskOptions.timeoutStrategy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,11 +270,12 @@ const generateRandomNumber = () => Math.floor( Math.random() * 100 );
 const randomNumber = await getResultFromIdleTask(generateRandomNumber, {
     priority: 'high',
     timeout: 3000,
+    timeoutStrategy: 'forceRun'
 });
 
 // same
 const taskId = setIdleTask(generateRandomNumber, { priority: 'high' });
-const randomNumber = await waitForIdleTask(taskId, { timeout: 3000, cache: false });
+const randomNumber = await waitForIdleTask(taskId, { timeout: 3000, cache: false, timeoutStrategy: 'forceRun' });
 ```
 
 You can get the result by using `getResultFromIdleTask` if you don't need the task id.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1495,7 +1495,10 @@ describe('idle-task', () => {
     let mockSetIdleTask: jest.SpyInstance;
     let mockWaitForIdleTask: jest.SpyInstance;
     const setIdleTaskOptions: SetIdleTaskOptions = { priority: 'high' };
-    const waitForIdleTaskOptions: WaitForIdleTaskOptions = { timeout: 3000 };
+    const waitForIdleTaskOptions: WaitForIdleTaskOptions = {
+      timeout: 3000,
+      timeoutStrategy: 'forceRun',
+    };
     let getResultFromIdleTaskPromise: Promise<any>;
 
     beforeEach(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,13 +29,36 @@ interface IdleTask extends IdleTaskFunction {
 let tasks: IdleTask[] = [];
 let requestIdleCallbackId: ReturnType<typeof rIC>;
 
+export interface SetIdleTaskOptions {
+  readonly priority?: 'low' | 'high';
+  readonly cache?: boolean;
+}
+
+export interface WaitForIdleTaskOptions {
+  readonly cache?: boolean;
+  readonly timeout?: number;
+  readonly timeoutStrategy?: IdleTaskTimeoutStrategy;
+}
+
+type ConfigurableSetIdleTaskOptions = Pick<WaitForIdleTaskOptions, 'cache'>;
+type ConfigurableWaitForIdleTaskOptions = Pick<
+  WaitForIdleTaskOptions,
+  'timeout' | 'timeoutStrategy'
+>;
+
+type ForceRunIdleTaskOptions = Pick<WaitForIdleTaskOptions, 'cache'>;
+
+export type GetResultFromIdleTaskOptions = Pick<
+  SetIdleTaskOptions,
+  'priority'
+> &
+  ConfigurableWaitForIdleTaskOptions;
+
 export type ConfigureOptions = {
   readonly interval?: number;
   readonly debug?: boolean;
-  readonly timeout?: number;
-  readonly cache?: boolean;
-  readonly timeoutStrategy?: IdleTaskTimeoutStrategy;
-};
+} & ConfigurableSetIdleTaskOptions &
+  ConfigurableWaitForIdleTaskOptions;
 
 let taskGlobalOptions: ConfigureOptions = {
   debug: false,
@@ -102,10 +125,6 @@ const runIdleTasks = (deadline: IdleDeadline): void => {
   requestIdleCallbackId = NaN;
 };
 
-export interface SetIdleTaskOptions {
-  readonly priority?: 'low' | 'high';
-  readonly cache?: boolean;
-}
 let id = 0;
 const defaultSetIdleTaskOptions: SetIdleTaskOptions = {
   priority: 'low',
@@ -170,12 +189,6 @@ export const isRunIdleTask = (id: number): boolean =>
 
 export type IdleTaskTimeoutStrategy = 'error' | 'forceRun';
 
-export interface WaitForIdleTaskOptions {
-  readonly cache?: boolean;
-  readonly timeout?: number;
-  readonly timeoutStrategy?: IdleTaskTimeoutStrategy;
-}
-
 const defaultWaitForIdleTaskOptions: WaitForIdleTaskOptions = {
   cache: true,
   timeoutStrategy: 'error',
@@ -232,12 +245,6 @@ export const waitForIdleTask = async (
   return racedResult;
 };
 
-export type GetResultFromIdleTaskOptions = Pick<
-  SetIdleTaskOptions,
-  'priority'
-> &
-  Pick<WaitForIdleTaskOptions, 'timeout' | 'timeoutStrategy'>;
-
 export const getResultFromIdleTask = (
   task: IdleTaskFunction,
   options?: GetResultFromIdleTaskOptions
@@ -247,8 +254,6 @@ export const getResultFromIdleTask = (
     timeout: options?.timeout,
     timeoutStrategy: options?.timeoutStrategy,
   });
-
-type ForceRunIdleTaskOptions = Pick<WaitForIdleTaskOptions, 'cache'>;
 
 const defaultForceRunIdleTaskOptions = defaultWaitForIdleTaskOptions;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ type ConfigurableWaitForIdleTaskOptions = Pick<
   'timeout' | 'timeoutStrategy'
 >;
 
-type ForceRunIdleTaskOptions = Pick<WaitForIdleTaskOptions, 'cache'>;
+export type ForceRunIdleTaskOptions = Pick<WaitForIdleTaskOptions, 'cache'>;
 
 export type GetResultFromIdleTaskOptions = Pick<
   SetIdleTaskOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,7 @@ export type GetResultFromIdleTaskOptions = Pick<
   SetIdleTaskOptions,
   'priority'
 > &
-  Pick<WaitForIdleTaskOptions, 'timeout'>;
+  Pick<WaitForIdleTaskOptions, 'timeout' | 'timeoutStrategy'>;
 
 export const getResultFromIdleTask = (
   task: IdleTaskFunction,
@@ -245,6 +245,7 @@ export const getResultFromIdleTask = (
   waitForIdleTask(setIdleTask(task, { priority: options?.priority }), {
     cache: false,
     timeout: options?.timeout,
+    timeoutStrategy: options?.timeoutStrategy,
   });
 
 type ForceRunIdleTaskOptions = Pick<WaitForIdleTaskOptions, 'cache'>;


### PR DESCRIPTION
- [feat: add GetResultFromIdleTaskOptions.timeoutStrategy](https://github.com/hiroki0525/idle-task/commit/bb54945300b5a1469ddecd254c00bf834f2a1a74)
- [fix: export ForceRunIdleTaskOptions type](https://github.com/hiroki0525/idle-task/commit/61e58016855e9bdf0e99fa5b0469094dca6d7b43)