### PR TITLE
feat: add `getIdleTaskStatus` instead of `isRunIdleTask`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ const taskId = setIdleTask(sendAnalyticsData, options);
 
 `setIdleTask` enqueues a task which `idle-task` will dequeue and run when the browser is idle.
 
-`setIdleTask` returns task id which is necessary for `cancelIdleTask` , `isRunIdleTask` and `waitForIdleTask`.
+`setIdleTask` returns task id which is necessary for `cancelIdleTask` , `getIdleTaskStatus` and `waitForIdleTask`.
 
 I recommend less than **50 ms** to execute a task because of [RAIL model](https://web.dev/i18n/en/rail/) .
 If you want to know how long did it take to finish a task, please use [debug mode](#debug-boolean) .
@@ -326,19 +326,29 @@ cancelAllIdleTasks();
 
 You can stop to run all tasks by using `cancelAllIdleTasks` if they are not executed.
 
-### `isRunIdleTask`
+### `getIdleTaskStatus`
 
 ```javascript
 const taskId = setIdleTask(() => console.log("task"));
-const isRun = isRunIdleTask(taskId);
-if (isRun) {
-  console.log("the task was completed");
+const idleTaskStatus = getIdleTaskStatus(taskId);
+// execute immediately if the task has not been executed yet.
+if (idleTaskStatus === 'ready') {
+  forceRunIdleTask(taskId)
 }
 ```
 
-**deprecated** : This function will be replaced alternative one.
+You can know the task status by using `getIdleTaskStatus` .
 
-You can know whether the task is executed or not by using `isRunIdleTask` .
+`getIdleTaskStatus` returns string as following.
+
+- `ready`
+  - The task has not been executed.
+- `executed`
+  - The task has been executed.
+  - **This doesn't mean that the task has been completed** because JavaScript don't have API which help us to know the promise result like `fullfilled` .
+- `unknown`
+  - `idle-task` doesn't know the task status because its result doesn't exist anywhere.
+  - This case means that the task was canceled by API like `cancelIdleTask` or its result was deleted by setting like `SetIdleTaskOptions.cache = false` .
 
 ### `configureIdleTask`
 

--- a/src/api/forceRunIdleTask.ts
+++ b/src/api/forceRunIdleTask.ts
@@ -1,5 +1,4 @@
 import type { WaitForIdleTaskOptions } from './waitForIdleTask';
-import isRunIdleTask from './isRunIdleTask';
 import {
   defaultWaitForIdleTaskOptions,
   executeTask,
@@ -8,6 +7,7 @@ import {
   idleTaskIdProp,
   idleTaskState as its,
 } from '../internals';
+import getIdleTaskStatus from './getIdleTaskStatus';
 
 export type ForceRunIdleTaskOptions = Pick<WaitForIdleTaskOptions, 'cache'>;
 
@@ -17,7 +17,7 @@ const forceRunIdleTask = async (
   id: number,
   options: ForceRunIdleTaskOptions = defaultForceRunIdleTaskOptions
 ): Promise<any> => {
-  if (isRunIdleTask(id)) {
+  if (getIdleTaskStatus(id) !== 'ready') {
     return getResultFromCache(id, options.cache === false);
   }
   const task = its.tasks.find(task => task[idleTaskIdProp] === id) as IdleTask;

--- a/src/api/getIdleTaskStatus.ts
+++ b/src/api/getIdleTaskStatus.ts
@@ -1,0 +1,22 @@
+import {
+  getResultFromCache,
+  idleTaskIdProp,
+  idleTaskState as its,
+} from '../internals';
+
+export type IdleTaskStatus = 'ready' | 'executed' | 'unknown';
+
+const getIdleTaskStatus = (id: number): IdleTaskStatus => {
+  if (its.tasks.some(task => task[idleTaskIdProp] === id)) {
+    return 'ready';
+  }
+  // We can't know JavaScript Promise states like fulfilled.
+  // 'unknown' means that the task was canceled or its result was deleted.
+  if (!getResultFromCache(id)) {
+    return 'unknown';
+  }
+  // WARNING: 'executed' means that the task was executed, not completed.
+  return 'executed';
+};
+
+export default getIdleTaskStatus;

--- a/src/api/isRunIdleTask.ts
+++ b/src/api/isRunIdleTask.ts
@@ -1,7 +1,0 @@
-import { idleTaskIdProp, idleTaskState as its } from '../internals';
-
-// deprecated
-const isRunIdleTask = (id: number): boolean =>
-  its.tasks.findIndex(task => task[idleTaskIdProp] === id) === -1;
-
-export default isRunIdleTask;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,6 +2,7 @@
 
 import type {
   ConfigureOptions,
+  IdleTaskStatus,
   SetIdleTaskOptions,
   WaitForIdleTaskOptions,
 } from './index';
@@ -529,29 +530,55 @@ describe('idle-task', () => {
     });
   });
 
-  describe('isRunIdleTask', () => {
-    let result: boolean;
+  describe('getIdleTaskStatus', () => {
+    let result: IdleTaskStatus;
 
     describe('is run', () => {
       beforeEach(() => {
         const taskId = idleTaskModule!.setIdleTask(createTask());
         runRequestIdleCallback();
-        result = idleTaskModule!.isRunIdleTask(taskId);
+        result = idleTaskModule!.getIdleTaskStatus(taskId);
       });
 
-      it('to be true', () => {
-        expect(result).toBe(true);
+      it('to be executed', () => {
+        expect(result).toBe('executed');
       });
     });
 
     describe('is not run', () => {
       beforeEach(() => {
         const taskId = idleTaskModule!.setIdleTask(createTask());
-        result = idleTaskModule!.isRunIdleTask(taskId);
+        result = idleTaskModule!.getIdleTaskStatus(taskId);
       });
 
-      it('to be false', () => {
-        expect(result).toBe(false);
+      it('to be ready', () => {
+        expect(result).toBe('ready');
+      });
+    });
+
+    describe('task is canceled', () => {
+      beforeEach(() => {
+        const taskId = idleTaskModule!.setIdleTask(createTask(), {
+          cache: false,
+        });
+        runRequestIdleCallback();
+        result = idleTaskModule!.getIdleTaskStatus(taskId);
+      });
+
+      it('to be unknown', () => {
+        expect(result).toBe('unknown');
+      });
+    });
+
+    describe('cache is deleted', () => {
+      beforeEach(() => {
+        const taskId = idleTaskModule!.setIdleTask(createTask());
+        idleTaskModule!.cancelIdleTask(taskId);
+        result = idleTaskModule!.getIdleTaskStatus(taskId);
+      });
+
+      it('to be unknown', () => {
+        expect(result).toBe('unknown');
       });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,12 @@ import forceRunIdleTask, {
 import getResultFromIdleTask, {
   GetResultFromIdleTaskOptions,
 } from './api/getResultFromIdleTask';
-import isRunIdleTask from './api/isRunIdleTask';
 import waitForIdleTask, {
   WaitForIdleTaskOptions,
   WaitForIdleTaskTimeoutError,
 } from './api/waitForIdleTask';
 import setIdleTask, { SetIdleTaskOptions } from './api/setIdleTask';
+import getIdleTaskStatus, { IdleTaskStatus } from './api/getIdleTaskStatus';
 
 export {
   cancelAllIdleTasks,
@@ -23,7 +23,8 @@ export {
   ForceRunIdleTaskOptions,
   getResultFromIdleTask,
   GetResultFromIdleTaskOptions,
-  isRunIdleTask,
+  getIdleTaskStatus,
+  IdleTaskStatus,
   waitForIdleTask,
   WaitForIdleTaskTimeoutError,
   WaitForIdleTaskOptions,


### PR DESCRIPTION
BREAKING CHANGE: `isRunIdleTask` was deleted. Please use `getIdleTaskStatus` if you want to know a task status.