### PR TITLE
feat: transpile ES2020 to reduce bundle size for modern browsers

### DIFF
--- a/.github/workflows/check-bundle-size.yml
+++ b/.github/workflows/check-bundle-size.yml
@@ -7,7 +7,7 @@ on:
     types: [synchronize, opened, reopened]
 
 jobs:
-  test:
+  check-bundle-size:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "sourceMap": true,
-    "target": "ES2017",
+    "target": "ES2020",
     "module": "esnext",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
This PR reduces `idle-task` bundle size to about [2.6%](https://github.com/hiroki0525/idle-task/pull/38#issuecomment-1374835259) .
If you bundle for legacy browsers, please use [CDN](https://github.com/hiroki0525/idle-task#install) .

- Features in ES2020 which are use by `idle-task`
  - [The Nullish Coalescing Operator (??)](https://www.w3schools.com/js/js_2020.asp#:~:text=ADVERTISEMENT-,The%20Nullish%20Coalescing%20Operator%20(%3F%3F),-The%20%3F%3F%20operator)
    - [Browsers support is 91.52%](https://caniuse.com/?search=Nullish%20Coalescing%20Operator)
  - [The Optional Chaining Operator (?.)](https://www.w3schools.com/js/js_2020.asp#:~:text=Mar%202020-,The%20Optional%20Chaining%20Operator%20(%3F.),-The%20Optional%20Chaining)
    - [Browsers support is 91.51%](https://caniuse.com/?search=Optional%20Chaining%20Operator)
- `idle-task` supports browser versions
  - Chrome 80
  - Edge 80
  - Firefox 74
  - Safari 13.1
  - Opera 67