### PR TITLE
fix: remove timer to reregister task when it was cancelled

### DIFF
--- a/src/__tests__/cancelAllIdleTasks.test.ts
+++ b/src/__tests__/cancelAllIdleTasks.test.ts
@@ -37,8 +37,8 @@ describe('cancelAllIdleTasks', () => {
       expect(mockCancelIdleCallback.mock.calls.length).toBe(1);
     });
 
-    it('first task result is cleared', () => {
-      expect(
+    it('first task result is cleared', async () => {
+      await expect(
         idleTaskModule!.waitForIdleTask(firstTaskId)
       ).resolves.toBeUndefined();
     });
@@ -49,8 +49,8 @@ describe('cancelAllIdleTasks', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('third task result is cleared', () => {
-      expect(
+    it('third task result is cleared', async () => {
+      await expect(
         idleTaskModule!.waitForIdleTask(thirdTaskId)
       ).resolves.toBeUndefined();
     });
@@ -81,20 +81,20 @@ describe('cancelAllIdleTasks', () => {
       expect(mockCancelIdleCallback.mock.calls.length).toBe(0);
     });
 
-    it('first task result is cleared', () => {
-      expect(
+    it('first task result is cleared', async () => {
+      await expect(
         idleTaskModule!.waitForIdleTask(firstTaskId)
       ).resolves.toBeUndefined();
     });
 
-    it('second task result is cleared', () => {
-      expect(
+    it('second task result is cleared', async () => {
+      await expect(
         idleTaskModule!.waitForIdleTask(secondTaskId)
       ).resolves.toBeUndefined();
     });
 
-    it('third task result is cleared', () => {
-      expect(
+    it('third task result is cleared', async () => {
+      await expect(
         idleTaskModule!.waitForIdleTask(thirdTaskId)
       ).resolves.toBeUndefined();
     });

--- a/src/__tests__/cancelAllIdleTasks.test.ts
+++ b/src/__tests__/cancelAllIdleTasks.test.ts
@@ -14,45 +14,103 @@ describe('cancelAllIdleTasks', () => {
   let thirdTaskId: number;
 
   describe('existed requestIdleCallback id', () => {
-    beforeEach(() => {
-      firstTaskId = idleTaskModule!.setIdleTask(createTask(mockFirstTask));
-      secondTaskId = idleTaskModule!.setIdleTask(createTask(mockSecondTask));
-      thirdTaskId = idleTaskModule!.setIdleTask(createTask(mockThirdTask));
-      idleTaskModule!.cancelAllIdleTasks();
+    describe('without revalidateInterval', () => {
+      beforeEach(() => {
+        firstTaskId = idleTaskModule!.setIdleTask(createTask(mockFirstTask));
+        secondTaskId = idleTaskModule!.setIdleTask(createTask(mockSecondTask));
+        thirdTaskId = idleTaskModule!.setIdleTask(createTask(mockThirdTask));
+        idleTaskModule!.cancelAllIdleTasks();
+        // check whether tasks were run or not
+        runRequestIdleCallback();
+      });
+
+      it('first task is not called', () => {
+        expect(mockFirstTask.mock.calls.length).toBe(0);
+      });
+
+      it('second task is not called', () => {
+        expect(mockSecondTask.mock.calls.length).toBe(0);
+      });
+
+      it('third task is not called', () => {
+        expect(mockThirdTask.mock.calls.length).toBe(0);
+      });
+
+      it('cancelIdleCallback is called', () => {
+        expect(mockCancelIdleCallback.mock.calls.length).toBe(1);
+      });
+
+      it('first task result is cleared', async () => {
+        await expect(
+          idleTaskModule!.waitForIdleTask(firstTaskId)
+        ).resolves.toBeUndefined();
+      });
+
+      it('second task result is cleared', () => {
+        expect(
+          idleTaskModule!.waitForIdleTask(secondTaskId)
+        ).resolves.toBeUndefined();
+      });
+
+      it('third task result is cleared', async () => {
+        await expect(
+          idleTaskModule!.waitForIdleTask(thirdTaskId)
+        ).resolves.toBeUndefined();
+      });
     });
 
-    it('first task is not called', () => {
-      expect(mockFirstTask.mock.calls.length).toBe(0);
-    });
+    describe('with revalidateInterval', () => {
+      beforeEach(() => {
+        firstTaskId = idleTaskModule!.setIdleTask(
+          createTask(mockFirstTask, 50),
+          {
+            revalidateInterval: 1,
+          }
+        );
+        secondTaskId = idleTaskModule!.setIdleTask(createTask(mockSecondTask));
+        thirdTaskId = idleTaskModule!.setIdleTask(createTask(mockThirdTask));
+        // one mockFirstTask will be executed and others will be enqueued
+        runRequestIdleCallback();
+        idleTaskModule!.cancelAllIdleTasks();
+        // check whether tasks were run or not
+        runRequestIdleCallback();
+        // check whether revalidateInterval worked or not
+        runRequestIdleCallback();
+      });
 
-    it('second task is not called', () => {
-      expect(mockSecondTask.mock.calls.length).toBe(0);
-    });
+      it('first task is called once', () => {
+        expect(mockFirstTask.mock.calls.length).toBe(1);
+      });
 
-    it('third task is not called', () => {
-      expect(mockThirdTask.mock.calls.length).toBe(0);
-    });
+      it('second task is not called', () => {
+        expect(mockSecondTask.mock.calls.length).toBe(0);
+      });
 
-    it('cancelIdleCallback is called', () => {
-      expect(mockCancelIdleCallback.mock.calls.length).toBe(1);
-    });
+      it('third task is not called', () => {
+        expect(mockThirdTask.mock.calls.length).toBe(0);
+      });
 
-    it('first task result is cleared', async () => {
-      await expect(
-        idleTaskModule!.waitForIdleTask(firstTaskId)
-      ).resolves.toBeUndefined();
-    });
+      it('cancelIdleCallback is called', () => {
+        expect(mockCancelIdleCallback.mock.calls.length).toBe(1);
+      });
 
-    it('second task result is cleared', () => {
-      expect(
-        idleTaskModule!.waitForIdleTask(secondTaskId)
-      ).resolves.toBeUndefined();
-    });
+      it('first task result is cleared', async () => {
+        await expect(
+          idleTaskModule!.waitForIdleTask(firstTaskId)
+        ).resolves.toBeUndefined();
+      });
 
-    it('third task result is cleared', async () => {
-      await expect(
-        idleTaskModule!.waitForIdleTask(thirdTaskId)
-      ).resolves.toBeUndefined();
+      it('second task result is cleared', () => {
+        expect(
+          idleTaskModule!.waitForIdleTask(secondTaskId)
+        ).resolves.toBeUndefined();
+      });
+
+      it('third task result is cleared', async () => {
+        await expect(
+          idleTaskModule!.waitForIdleTask(thirdTaskId)
+        ).resolves.toBeUndefined();
+      });
     });
   });
 
@@ -63,6 +121,8 @@ describe('cancelAllIdleTasks', () => {
       thirdTaskId = idleTaskModule!.setIdleTask(createTask(mockThirdTask));
       runRequestIdleCallback();
       idleTaskModule!.cancelAllIdleTasks();
+      // check whether tasks were run or not
+      runRequestIdleCallback();
     });
 
     it('first task is called', () => {

--- a/src/__tests__/cancelIdleTask.test.ts
+++ b/src/__tests__/cancelIdleTask.test.ts
@@ -32,8 +32,8 @@ describe('cancelIdleTask', () => {
         expect(mockThirdTask.mock.calls.length).toBe(1);
       });
 
-      it('first task result is cleared', () => {
-        expect(
+      it('first task result is cleared', async () => {
+        await expect(
           idleTaskModule!.waitForIdleTask(taskId)
         ).resolves.toBeUndefined();
       });
@@ -64,8 +64,8 @@ describe('cancelIdleTask', () => {
         expect(mockThirdTask.mock.calls.length).toBe(1);
       });
 
-      it('second task result is cleared', () => {
-        expect(
+      it('second task result is cleared', async () => {
+        await expect(
           idleTaskModule!.waitForIdleTask(taskId)
         ).resolves.toBeUndefined();
       });
@@ -98,8 +98,8 @@ describe('cancelIdleTask', () => {
         expect(mockThirdTask.mock.calls.length).toBe(1);
       });
 
-      it('second task result is cleared', () => {
-        expect(
+      it('second task result is cleared', async () => {
+        await expect(
           idleTaskModule!.waitForIdleTask(taskId)
         ).resolves.toBeUndefined();
       });
@@ -127,8 +127,10 @@ describe('cancelIdleTask', () => {
       expect(mockThirdTask.mock.calls.length).toBe(0);
     });
 
-    it('first task result is cleared', () => {
-      expect(idleTaskModule!.waitForIdleTask(taskId)).resolves.toBeUndefined();
+    it('first task result is cleared', async () => {
+      await expect(
+        idleTaskModule!.waitForIdleTask(taskId)
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/src/__tests__/cancelIdleTask.test.ts
+++ b/src/__tests__/cancelIdleTask.test.ts
@@ -71,7 +71,7 @@ describe('cancelIdleTask', () => {
       });
     });
 
-    describe('one task is not canceled and another task is canceled', () => {
+    describe('one task is not canceled and others is canceled', () => {
       beforeEach(() => {
         idleTaskModule!.setIdleTask(createTask(mockFirstTask, 50));
         taskId = idleTaskModule!.setIdleTask(createTask(mockSecondTask, 50), {
@@ -79,10 +79,12 @@ describe('cancelIdleTask', () => {
         });
         // mockFirstTask will be executed and 2 mockSecondTask will be remaining.
         runRequestIdleCallback();
-        // one mockSecondTask will be executed and another mockSecondTask will be remaining.
+        // one mockSecondTask will be executed and 2 mockSecondTask will be remaining.
         runRequestIdleCallback();
         idleTaskModule!.setIdleTask(createTask(mockThirdTask));
         idleTaskModule!.cancelIdleTask(taskId);
+        runRequestIdleCallback();
+        // check whether revalidateInterval worked or not
         runRequestIdleCallback();
       });
 

--- a/src/api/setIdleTask.ts
+++ b/src/api/setIdleTask.ts
@@ -95,14 +95,10 @@ const setIdleTask = (
     : its.tasks.push(idleTask);
   const { revalidateInterval } = options;
   if (revalidateInterval !== undefined) {
-    const reregisterIdleTask = (): void => {
-      setTimeout(() => {
-        // Low Priority
-        its.tasks.push(idleTask);
-        reregisterIdleTask();
-      }, revalidateInterval);
-    };
-    reregisterIdleTask();
+    setInterval(() => {
+      // Low Priority
+      its.tasks.push(idleTask);
+    }, revalidateInterval);
   }
   if (its.requestIdleCallbackId) {
     return idleTaskId;

--- a/src/api/setIdleTask.ts
+++ b/src/api/setIdleTask.ts
@@ -73,6 +73,7 @@ const setIdleTask = (
       })
     );
   }
+  const { revalidateInterval } = options;
   const idleTask = Object.defineProperties(() => task(), {
     id: {
       value: idleTaskId,
@@ -89,17 +90,19 @@ const setIdleTask = (
     revalidateWhenExecuted: {
       value: options.revalidateWhenExecuted,
     },
+    revalidateIntervalId: {
+      value:
+        revalidateInterval === undefined
+          ? NaN
+          : setInterval(() => {
+              // Low Priority
+              its.tasks.push(idleTask);
+            }, revalidateInterval),
+    },
   }) as IdleTask;
   options.priority === 'high'
     ? its.tasks.unshift(idleTask)
     : its.tasks.push(idleTask);
-  const { revalidateInterval } = options;
-  if (revalidateInterval !== undefined) {
-    setInterval(() => {
-      // Low Priority
-      its.tasks.push(idleTask);
-    }, revalidateInterval);
-  }
   if (its.requestIdleCallbackId) {
     return idleTaskId;
   }

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -29,6 +29,7 @@ export interface IdleTask extends IdleTaskFunction {
   readonly resolve?: PromiseResolveReject[0];
   readonly reject?: PromiseResolveReject[1];
   readonly revalidateWhenExecuted?: boolean;
+  readonly revalidateIntervalId: number;
 }
 
 export type ConfigurableWaitForIdleTaskOptions = Pick<
@@ -55,6 +56,7 @@ export const executeTask = (task: IdleTask): void => {
 };
 
 export const resolveTaskResultWhenCancel = (task: IdleTask): void => {
+  clearInterval(task.revalidateIntervalId);
   const resolve = task.resolve;
   resolve && resolve(undefined);
 };


### PR DESCRIPTION
Please see the following example.

```js
const taskId = setIdleTask(yourTask, { revalidateInterval: 5000 });
// The task is deleted, but `idle-task` will enqueue it every 5000 ms .
cancelIdleTask(taskId);
// or cancelAllIdleTasks();
```

This PR fix it.
Reregistering the task is stopped if you use `cancelIdleTask` or `cancelAllIdleTasks` .