### PR TITLE
fix: infinite loop when use `revalidateWhenExecuted`

### DIFF
--- a/src/__tests__/setIdleTask.test.ts
+++ b/src/__tests__/setIdleTask.test.ts
@@ -307,15 +307,35 @@ describe('setIdleTask', () => {
 
     describe('with revalidateWhenExecuted', () => {
       describe('revalidateWhenExecuted is true', () => {
-        beforeEach(() => {
-          idleTaskModule!.setIdleTask(createTask(mockFirstTask, 25), {
-            revalidateWhenExecuted: true,
+        describe('not called cancelIdleTask', () => {
+          beforeEach(() => {
+            idleTaskModule!.setIdleTask(createTask(mockFirstTask, 25), {
+              revalidateWhenExecuted: true,
+            });
+            runRequestIdleCallback();
           });
-          runRequestIdleCallback();
-        });
 
-        it('first task is called twice', () => {
-          expect(mockFirstTask.mock.calls.length).toBe(2);
+          it('first task is called twice', () => {
+            expect(mockFirstTask.mock.calls.length).toBe(2);
+          });
+        });
+        describe('called cancelIdleTask', () => {
+          beforeEach(() => {
+            const key = idleTaskModule!.setIdleTask(
+              createTask(() => {
+                mockFirstTask();
+                idleTaskModule!.cancelIdleTask(key);
+              }, 25),
+              {
+                revalidateWhenExecuted: true,
+              }
+            );
+            runRequestIdleCallback();
+          });
+
+          it('first task is called once', () => {
+            expect(mockFirstTask.mock.calls.length).toBe(1);
+          });
         });
       });
     });

--- a/src/__tests__/util.ts
+++ b/src/__tests__/util.ts
@@ -35,7 +35,7 @@ export const mockThirdTask = jest
   .mockImplementation(() => 'mockThirdTask');
 
 export const createTask =
-  (mockFunction?: jest.Mock, time = 0) =>
+  (mockFunction?: () => any, time = 0) =>
   () => {
     if (mockFunction) {
       jest.advanceTimersByTime(time);

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -39,19 +39,18 @@ export type ConfigurableWaitForIdleTaskOptions = Pick<
 
 export const executeTask = (task: IdleTask): void => {
   const { resolve, reject, revalidateWhenExecuted } = task;
-  const reregisterIdleTask = () =>
-    revalidateWhenExecuted && idleTaskState.tasks.push(task);
+  // reregister a task before executing the task because it may contain `cancelIdleTask` .
+  if (revalidateWhenExecuted) {
+    idleTaskState.tasks.push(task);
+  }
   if (!resolve || !reject) {
     task();
-    reregisterIdleTask();
     return;
   }
   try {
     resolve(task());
   } catch (e) {
     reject(e);
-  } finally {
-    reregisterIdleTask();
   }
 };
 


### PR DESCRIPTION
An infinite loop occurs when use `revalidateWhenExecuted`. This PR is to fix this.

```js
// infinite loop
let counter = 0;
const maxCounter = 3;
const key = setIdleTask(
  () => {
    if (counter < maxCounter) {
      // not working
      cancelIdleTask(key);
    }
    counter++;
  },
  { revalidateWhenExecuted: true }
);
```